### PR TITLE
Added test to read into the datalake

### DIFF
--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -2,7 +2,6 @@ name: Run ESCAPE testsuite
 
 on:
   push:
-    branches: [ main ]
 
   schedule:
     - cron: '0/4 * * * *'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /reports/*
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
 # ESCAPE AuthN/Z test suite 
 
 TBD
+
+## Running the testsuite with docker
+
+This is the recommended way of running the testsuite. It requires you have a local oidc-agent configuration with a client named `escape-monitoring` registered on the [iam-escape](https://iam-escape.cloud.cnaf.infn.it/) instance.
+
+To setup an environment for running the testsuite in docker,
+use the following commands:
+
+```bash
+docker-compose up trust # and wait for fetch crl to be done
+docker-compose up -d ts
+```
+
+Then run the entire testsuite with
+
+```bash
+docker-compose exec -T ts bash -c 'cd test-suite && OIDC_AGENT_SECRET=<secret> sh ci/run.sh'
+```
+where `<secret>` is the `escape-monitoring` client's secret.
+
+### Datalake
+
+The testsuite can also be runned against one of the registered endpoint.
+
+Once the testsuite is UP, you can log into the container:
+
+```bash
+docker-compose exec ts bash
+```
+
+You will need to initialize oidc-agent inside the container. 
+
+```bash
+$ eval $(oidc-agent --no-autoload)
+$ oidc-add escape-monitoring
+```
+
+You can then run the testsuite against one of the registered endpoint, _e.g._ `cnaf-amnesiac`
+
+```bash
+cd test-suite
+./run-testsuite.sh cnaf-amnesiac
+```
+
+To add an endpoint, edit the `./test/variables.yaml` file.

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -70,6 +70,9 @@ endpoints=$(cat test/variables.yaml | shyaml keys endpoints | grep -v storm-exam
 
 set +e
 
+REPORTS_DIR=${reports_dir} ./run-testsuite.sh 
+rm -rf ${proxy_file}
+
 for e in ${endpoints}; do
   REPORTS_DIR=${reports_dir}/${e} ./run-testsuite.sh ${e}
 done
@@ -77,8 +80,6 @@ done
 reports=$(find ${reports_dir} -name output.xml)
 
 set -e
-
-rm -rf ${proxy_file}
 
 echo "Creating final report..."
 rebot --nostatusrc \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -71,7 +71,10 @@ endpoints=$(cat test/variables.yaml | shyaml keys endpoints | grep -v storm-exam
 set +e
 
 REPORTS_DIR=${reports_dir} ./run-testsuite.sh 
+
+# remove proxy if you don't need it in the next test suite
 rm -rf ${proxy_file}
+unset X509_USER_PROXY
 
 for e in ${endpoints}; do
   REPORTS_DIR=${reports_dir}/${e} ./run-testsuite.sh ${e}

--- a/common/endpoint.robot
+++ b/common/endpoint.robot
@@ -10,7 +10,7 @@ Get SE config
     [Return]   ${se_cfg}
 
 Get SE endpoint
-    [Arguments]   ${se_alias}   ${sa}=wlcg
+    [Arguments]   ${se_alias}   ${sa}=escape
     ${se_cfg}   Get SE config   ${se_alias}
     ${sa_path}   Get From Dictionary   ${se_cfg.paths}   ${sa}
     [Return]   ${se_cfg.endpoint}${sa_path}

--- a/common/utils.robot
+++ b/common/utils.robot
@@ -52,19 +52,19 @@ Create Random Temporary File
     [Return]   ${path}
 
 Suite Base URL
-    [Arguments]   ${se}=${se_alias}   ${sa}=wlcg
+    [Arguments]   ${se}=${se_alias}   ${sa}=escape
     ${endpoint}   GET SE endpoint   ${se_alias}   ${sa}
-    ${url}   Set Variable   ${endpoint}/wlcg-jwt-compliance/${SUITE_UUID}
+    ${url}   Set Variable   ${endpoint}/escape-jwt-compliance/${SUITE_UUID}
     [Return]   ${url}
 
 SE URL
-    [Arguments]  ${path}  ${se}=${se_alias}   ${sa}=wlcg
+    [Arguments]  ${path}  ${se}=${se_alias}   ${sa}=escape
     ${suite_url}   Suite Base URl   ${se_alias}   ${sa}
     ${url}   Set Variable   ${suite_url}/${path}
     [Return]   ${url}
 
 Create Suite Directory
-    [Arguments]   ${sa}=wlcg
+    [Arguments]   ${sa}=escape
     ${endpoint}   GET SE endpoint   ${se_alias}   ${sa}
-    Se Create Dir If Missing   ${endpoint}/wlcg-jwt-compliance
-    Se Create Dir If Missing   ${endpoint}/wlcg-jwt-compliance/${SUITE_UUID}
+    Se Create Dir If Missing   ${endpoint}/escape-jwt-compliance
+    Se Create Dir If Missing   ${endpoint}/escape-jwt-compliance/${SUITE_UUID}

--- a/run-testsuite.sh
+++ b/run-testsuite.sh
@@ -16,18 +16,11 @@
 #
 set -e
 
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <seAlias>"
-  exit 1
-fi
-
 REPORTS_DIR=${REPORTS_DIR:-reports/$1}
-
-DEFAULT_EXCLUDES=${DEFAULT_EXCLUDES:-"-e iam"}
 
 ROBOT_ARGS=${ROBOT_ARGS:-}
 
-DEFAULT_ARGS="--pythonpath .:common -d ${REPORTS_DIR} ${DEFAULT_EXCLUDES}"
+DEFAULT_ARGS="--pythonpath .:common -d ${REPORTS_DIR}"
 
 ARGS=${DEFAULT_ARGS}
 
@@ -37,5 +30,13 @@ fi
 
 alias python='python3'
 
-echo "Datalake test suite run against: $1"
-robot ${ARGS} --variable se_alias:$1 --name $1 -G $1 test 
+if [ $# -eq 0 ]; then
+  robot ${ARGS} test/iam
+elif [ $# -eq 1 ]; then
+  echo "Datalake test suite run against: $1"
+  robot ${ARGS} --variable se_alias:$1 --name $1 -G $1 test/datalake
+else
+  echo "Invalid number of arguments"
+  exit 1
+fi
+ 

--- a/run-testsuite.sh
+++ b/run-testsuite.sh
@@ -16,11 +16,18 @@
 #
 set -e
 
-REPORTS_DIR=${REPORTS_DIR:-reports}
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <seAlias>"
+  exit 1
+fi
+
+REPORTS_DIR=${REPORTS_DIR:-reports/$1}
+
+DEFAULT_EXCLUDES=${DEFAULT_EXCLUDES:-"-e iam"}
 
 ROBOT_ARGS=${ROBOT_ARGS:-}
 
-DEFAULT_ARGS="--pythonpath .:common -d ${REPORTS_DIR}"
+DEFAULT_ARGS="--pythonpath .:common -d ${REPORTS_DIR} ${DEFAULT_EXCLUDES}"
 
 ARGS=${DEFAULT_ARGS}
 
@@ -30,4 +37,5 @@ fi
 
 alias python='python3'
 
-robot ${ARGS} test 
+echo "Datalake test suite run against: $1"
+robot ${ARGS} --variable se_alias:$1 --name $1 -G $1 test 

--- a/test/datalake/permissions.robot
+++ b/test/datalake/permissions.robot
@@ -13,4 +13,5 @@ Force Tags   read-permissions
 Read access granted to ESCAPE members
     ${token}   Get token   scope=-s openid
     ${endpoint}   GET SE endpoint   ${se_alias}
-    Execute and Check Success   gfal-ls ${endpoint}
+    ${rc}  ${output}  Execute and Check Success   gfal-ls -d ${endpoint}
+    Should Contain   ${output}  ${endpoint}

--- a/test/datalake/permissions.robot
+++ b/test/datalake/permissions.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+
+Resource    common/endpoint.robot
+Resource    common/oidc-agent.robot
+Resource    common/utils.robot
+
+Variables   test/variables.yaml
+
+Force Tags   read-permissions
+
+*** Test cases ***
+
+Read access granted to ESCAPE members
+    ${token}   Get token   scope=-s openid
+    ${endpoint}   GET SE endpoint   ${se_alias}
+    Execute and Check Success   gfal-ls ${endpoint}

--- a/test/variables.yaml
+++ b/test/variables.yaml
@@ -9,12 +9,12 @@ endpoints:
   infn-t1-webdav:
     desc: INFN T1 webdav endpoint
     type: StoRM
-    endpoint: https://xfer.cr.cnaf.infn.it:8443
+    endpoint: davs://xfer.cr.cnaf.infn.it:8443
     paths:
       escape: /escape
   cnaf-amnesiac:
     desc: CNAF StoRM development instance
     type: StoRM
-    endpoint: https://amnesiac.cloud.cnaf.infn.it:8443
+    endpoint: davs://amnesiac.cloud.cnaf.infn.it:8443
     paths:
       escape: /escape

--- a/test/variables.yaml
+++ b/test/variables.yaml
@@ -12,3 +12,9 @@ endpoints:
     endpoint: https://xfer.cr.cnaf.infn.it:8443
     paths:
       escape: /escape
+  cnaf-amnesiac:
+    desc: CNAF StoRM development instance
+    type: StoRM
+    endpoint: https://amnesiac.cloud.cnaf.infn.it:8443
+    paths:
+      escape: /escape


### PR DESCRIPTION
The Permissions testsuite basically checks whether a token issued by the iam-escape instance with `openid` scope can read into the datalake.
New endpoints of the datalake can be customized in the `./test/variables.yaml` file.

Also set CI trigger on push to any branch