### PR TITLE
Issue 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # ESCAPE AuthN/Z test suite
 
+Documentation on token based authN/Z in the ESCAPE Datalake can be found [here](https://github.com/indigo-iam/escape-docs#token-based-authnz).
+
 ## Running the testsuite with docker
 
-This is the recommended way of running the testsuite. It requires you have a local oidc-agent configuration with a client named `escape-monitoring` registered on the [iam-escape](https://iam-escape.cloud.cnaf.infn.it/) instance.
+This is the recommended way of running the testsuite. It requires you have a local oidc-agent configuration with two clients registered on the [iam-escape](https://iam-escape.cloud.cnaf.infn.it/) instance:
+
+* `escape-monitoring`, for token-based authz tests with `/escape` group;
+* `escape-auth-tests-cms`, for token-based authz tests with the more priviledged `/escape/data-manager` group.
 
 To setup an environment for running the testsuite in docker,
 use the following commands:
@@ -15,16 +20,19 @@ docker-compose up -d ts
 Then run the entire testsuite with
 
 ```bash
-docker-compose exec -T ts bash -c 'cd test-suite && OIDC_AGENT_SECRET=<secret> sh ci/run.sh'
+docker-compose exec -T ts bash -c 'cd test-suite && OIDC_AGENT_SECRET=<secret_escape> OIDC_AGENT_CMS_SECRET=<secret_data-manager> sh ci/run.sh'
 ```
 
-where `<secret>` is the `escape-monitoring` client's secret.
+where 
+
+* `<secret_escape>` is the `escape-monitoring` client's secret;
+* `<secret_data-manager>` is the `escape-auth-tests-cms` client's secret.
 
 ### Datalake
 
 The testsuite can also be runned against one of the registered endpoint.
 
-Once the testsuite is UP, you can log into the container:
+Once the testsuite is UP, you can log into the container with
 
 ```bash
 docker-compose exec ts bash
@@ -35,22 +43,23 @@ You will need to initialize oidc-agent inside the container.
 ```bash
 eval $(oidc-agent --no-autoload)
 oidc-add escape-monitoring
+oidc-add escape-auth-tests-cms
 ```
 
 You can then run the testsuite against one of the registered endpoint, _e.g._ `cnaf-amnesiac`
 
 ```bash
 cd test-suite
-./run-testsuite.sh cnaf-amnesiac
+sh run-testsuite.sh cnaf-amnesiac
 ```
 
 To add an endpoint, edit the `./test/variables.yaml` file.
 
 This [JSON document](https://escape-cric.cern.ch/api/doma/rse/query/?json&preset=doma) provides a list of active RSEs in the Datalake.  
-To fetch the list of Datalake endpoints compatible with the `./test/variables.yaml` file, run
+To fetch the list of Datalake endpoints (which can be cut-and-pasted in the `test/variables.yaml` file), run
 
 ```console
-./ci/assets/fetch-rses-from-cric.sh
+sh utils/fetch-rses-from-cric.sh
 ```
 
 ## CI test suite run

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -34,17 +34,6 @@ ec_iam=$?
 
 if [ -z "${SKIP_DATALAKE_TESTSUITE}" ]; then
 
-  echo -e "\nLooking for new RSEs from CRIC..."
-
-  ./utils/fetch-rses-from-cric.sh > /dev/null 2>&1
-
-  if [ $? -eq 0 ]; then
-      echo -e "Already up to date.\n"
-  else
-      echo    "WARNING: your 'variables.yaml' file is not up to date."
-      echo -e "Please add missing datalake endpoints.\n"
-  fi
-
   endpoints=$(cat test/variables.yaml | shyaml keys endpoints)
 
   ec_dl=0

--- a/common/utils.robot
+++ b/common/utils.robot
@@ -91,7 +91,7 @@ Upload file in sub-suite Directory with VOMS proxy
     ${url}   Create sub-suite Directory with VOMS proxy   ${prefix.dir}
     ${local_file}   Create Random Temporary File   ${content}
     ${file.basename}   Run   basename ${local_file}
-    ${rc}   ${out}   Gfal copy Success   ${local_file}   ${url}
+    ${rc}   ${out}   Gfal copy Success   ${local_file}   ${url}   -t 15
     Should Contain   ${out}   ${url}/${file.basename}
     Remove Temporary file   ${file.basename}
     [Return]   ${url}   ${file.basename}

--- a/common/utils.robot
+++ b/common/utils.robot
@@ -91,7 +91,7 @@ Upload file in sub-suite Directory with VOMS proxy
     ${url}   Create sub-suite Directory with VOMS proxy   ${prefix.dir}
     ${local_file}   Create Random Temporary File   ${content}
     ${file.basename}   Run   basename ${local_file}
-    ${rc}   ${out}   Gfal copy Success   ${local_file}   ${url}   -t 15
+    ${rc}   ${out}   Gfal copy Success   ${local_file}   ${url}   -t 5
     Should Contain   ${out}   ${url}/${file.basename}
     Remove Temporary file   ${file.basename}
     [Return]   ${url}   ${file.basename}

--- a/test/datalake/anonymous_authz/step_0.robot
+++ b/test/datalake/anonymous_authz/step_0.robot
@@ -37,6 +37,7 @@ Delete file denied to unauthenticated clients
     Delete VOMS proxy
     ${rc}   ${out}   Gfal rm Error  ${url}/${file.basename}
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
+    [Teardown]   Run   voms-proxy-destroy
 
 Create directory denied to unauthenticated clients
     ${uuid}   Generate UUID
@@ -49,3 +50,4 @@ Delete directory denied to unauthenticated clients
     Delete VOMS proxy
     ${rc}   ${out}   Gfal rm Error  ${url}   -r
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
+    [Teardown]   Run   voms-proxy-destroy

--- a/test/datalake/anonymous_authz/step_0.robot
+++ b/test/datalake/anonymous_authz/step_0.robot
@@ -33,7 +33,7 @@ Write file denied to unauthenticated clients
     Remove Temporary File   ${file.basename}
 
 Delete file denied to unauthenticated clients
-    ${url}   ${file.basename}   Upload file in sub-suite Directory with VOMS proxy   anonymous-delete-file-denied
+    ${url}   ${file.basename}   Upload file in sub-suite Directory with VOMS proxy   anonymous-delete-file-denied   random-content
     Delete VOMS proxy
     ${rc}   ${out}   Gfal rm Error  ${url}/${file.basename}
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True

--- a/test/datalake/group_based_authz/step_0.robot
+++ b/test/datalake/group_based_authz/step_0.robot
@@ -25,7 +25,7 @@ Read file allowed to default groups
     Should Contain   ${out}   ${file.content}
 
 Write file allowed to default groups
-    ${rc}   ${out}   Gfal copy Success   /etc/services   ${url}
+    ${rc}   ${out}   Gfal copy Success   /etc/services   ${url}   -f
     Should Contain   ${out}   ${url}/services
 
 Delete file allowed to default groups

--- a/test/variables.yaml
+++ b/test/variables.yaml
@@ -41,6 +41,20 @@ endpoints:
     endpoint: davs://eoseulake.cern.ch:443
     paths:
       prefix: //eos/eulake/tests/rucio_test/eulake_1/EC42/
+  fair-root:
+    enable: true
+    desc: FAIR-ROOT-davs
+    type:
+    endpoint: davs://lxwp2dlds1.gsi.de:443
+    paths:
+      prefix: //escape/fair_root
+  gsi-root:
+    enable: true
+    desc: GSI-ROOT-davs
+    type:
+    endpoint: davs://dclxwp2dlds1.gsi.de:443
+    paths:
+      prefix: //escape/gsi_root
   in2p3-cc-dcache:
     enable: true
     desc: CC-IN2P3-DCACHE-davs

--- a/utils/fetch-rses-from-cric.sh
+++ b/utils/fetch-rses-from-cric.sh
@@ -15,21 +15,25 @@ for k in "${keys[@]}"; do
 		continue;
 	fi
 
-	scheme=$(echo $rse_list | jq -r .rses.$k.protocols[0].scheme)
-	
-	if [[ "$scheme" =~ ^(davs|https)$ ]]; then
-		desc=$(echo $rse_list | jq -r .rses.$k.protocols[0].name)
-		port=$(echo $rse_list | jq -r .rses.$k.protocols[0].port)
-		prefix=$(echo $rse_list | jq -r .rses.$k.protocols[0].prefix)
-		hostname=$(echo $rse_list | jq -r .rses.$k.protocols[0].hostname)
-		echo "  $name:"
-		echo "    enable: true"
-		echo "    desc: $desc"
-		echo "    type:"
-		echo "    endpoint: $scheme://$hostname:$port"
-		echo "    paths:"
-		echo "      prefix: $prefix"
-	else
-		>&2 echo "Skipping endpoint ${name} that has scheme ${scheme}"
-	fi
+	protocols=($(echo $rse_list | jq .rses.$k.protocols | jq keys[]))
+
+	for i in "${protocols[@]}"; do
+		scheme=$(echo $rse_list | jq -r .rses.$k.protocols[$i].scheme)
+		
+		if [[ "$scheme" =~ ^(davs|https)$ ]]; then
+			desc=$(echo $rse_list | jq -r .rses.$k.protocols[$i].name)
+			port=$(echo $rse_list | jq -r .rses.$k.protocols[$i].port)
+			prefix=$(echo $rse_list | jq -r .rses.$k.protocols[$i].prefix)
+			hostname=$(echo $rse_list | jq -r .rses.$k.protocols[$i].hostname)
+			echo "  $name:"
+			echo "    enable: true"
+			echo "    desc: $desc"
+			echo "    type:"
+			echo "    endpoint: $scheme://$hostname:$port"
+			echo "    paths:"
+			echo "      prefix: $prefix"
+		else
+			>&2 echo "Skipping endpoint ${name} that has scheme ${scheme}"
+		fi
+	done
 done


### PR DESCRIPTION
- standalone script for fetching CRIC endpoints (`fetch-rses-from-cric.sh`), not used in CI anymore;
- added `gsi-root` and `fair-root` endpoints;
- upload not-empty file with gfal-copy (otherwise we reach timeout on xrootd endpoints)