### PR TITLE
Issue 13

### DIFF
--- a/common/utils.robot
+++ b/common/utils.robot
@@ -112,3 +112,9 @@ Upload File in Suite Sub-Directory
     Should Contain   ${out}   ${url}/${file.basename}
     Remove Temporary file   ${file.basename}
     [Return]   ${url}   ${file.basename}
+
+Set Suite Environment
+    [Arguments]   ${prefix.dir}=ts   ${content}=${EMPTY}
+    ${url}   ${file.basename}   Upload File in Suite Sub-Directory   ${prefix.dir}   ${content}
+    Set Suite Variable   ${url}
+    Set Suite Variable   ${file.basename}

--- a/common/utils.robot
+++ b/common/utils.robot
@@ -82,14 +82,27 @@ Set Authorization Method
     Should Contain   ${out}   Created proxy in
     ${status}   ${value}   Run Keyword And Ignore Error   Gfal mkdir Success   ${url}
     IF   '${status}' == 'FAIL'
-    Delete VOMS proxy   
-    Get token
+    Set Global Variable   ${AUTHZ_METHOD}   token
     Log    Authorization method used: BEARER token
     ELSE IF   '${status}' == 'PASS'
+    Set Global Variable   ${AUTHZ_METHOD}   proxy
     Log    Authorization method used: VOMS proxy
     ELSE
+    Set Global Variable   ${AUTHZ_METHOD}  None
     Log   Unexpected Keyword Status: '${status}'
     END
+    Delete VOMS proxy
+
+Get Authorization Method
+    IF   '${AUTHZ_METHOD}' == 'proxy'
+    ${rc}   ${out}   Create VOMS proxy
+    Should Contain   ${out}   Created proxy in
+    ELSE IF   '${AUTHZ_METHOD}' == 'token'
+    Get token
+    ELSE
+    Log   No authorization method set; failing test setup and skipping test suite
+    END
+
 
 Cleanup Authorization Environment
     Remove Environment Variable   BEARER_TOKEN

--- a/common/utils.robot
+++ b/common/utils.robot
@@ -77,16 +77,31 @@ Get NOW Time
     ${year}  ${month}  ${day}  ${hour}  ${min}  ${sec}   Get Time   year month day hour min sec
     [Return]   ${year}${month}${day}_${hour}${min}${sec}
 
-Get Authorization Method
-    IF   '${AUTHZ_METHOD}' == 'proxy'
-    ${rc}   ${out}   Create VOMS proxy
+Set Fixture Authorization Method
+    ${rc}   ${out}   Create Fixture VOMS proxy
     Should Contain   ${out}   Created proxy in
+    Enable Fixture VOMS proxy
+    ${status}   ${value}   Run Keyword And Ignore Error   Gfal mkdir Success   ${url}
+    IF   '${status}' == 'FAIL'
+    Set Global Variable   ${AUTHZ_METHOD}   token
+    Log    Authorization method used: BEARER token
+    ELSE IF   '${status}' == 'PASS'
+    Set Global Variable   ${AUTHZ_METHOD}   proxy
+    Log    Authorization method used: VOMS proxy
+    ELSE
+    Set Global Variable   ${AUTHZ_METHOD}  None
+    Log   Unexpected Keyword Status: '${status}'   level=WARN
+    END
+    Delete VOMS proxy
+
+Get Fixture Authorization Method
+    IF   '${AUTHZ_METHOD}' == 'proxy'
+    Enable Fixture VOMS proxy
     ELSE IF   '${AUTHZ_METHOD}' == 'token'
     Get token
     ELSE
-    Log   No authorization method set. Failing test setup and skipping test suite
+    Log   No authorization method set. Failing test setup and skipping test suite   level=WARN
     END
-
 
 Cleanup Authorization Environment
     Remove Environment Variable   BEARER_TOKEN

--- a/common/utils.robot
+++ b/common/utils.robot
@@ -84,9 +84,9 @@ Set Authorization Method
     IF   '${status}' == 'FAIL'
     Delete VOMS proxy   
     Get token
-    Log    Authentication method used: BEARER token
+    Log    Authorization method used: BEARER token
     ELSE IF   '${status}' == 'PASS'
-    Log    Authentication method used: VOMS proxy
+    Log    Authorization method used: VOMS proxy
     ELSE
     Log   Unexpected Keyword Status: '${status}'
     END

--- a/common/utils.robot
+++ b/common/utils.robot
@@ -77,22 +77,6 @@ Get NOW Time
     ${year}  ${month}  ${day}  ${hour}  ${min}  ${sec}   Get Time   year month day hour min sec
     [Return]   ${year}${month}${day}_${hour}${min}${sec}
 
-Set Authorization Method
-    ${rc}   ${out}   Create VOMS proxy
-    Should Contain   ${out}   Created proxy in
-    ${status}   ${value}   Run Keyword And Ignore Error   Gfal mkdir Success   ${url}
-    IF   '${status}' == 'FAIL'
-    Set Global Variable   ${AUTHZ_METHOD}   token
-    Log    Authorization method used: BEARER token
-    ELSE IF   '${status}' == 'PASS'
-    Set Global Variable   ${AUTHZ_METHOD}   proxy
-    Log    Authorization method used: VOMS proxy
-    ELSE
-    Set Global Variable   ${AUTHZ_METHOD}  None
-    Log   Unexpected Keyword Status: '${status}'
-    END
-    Delete VOMS proxy
-
 Get Authorization Method
     IF   '${AUTHZ_METHOD}' == 'proxy'
     ${rc}   ${out}   Create VOMS proxy
@@ -100,7 +84,7 @@ Get Authorization Method
     ELSE IF   '${AUTHZ_METHOD}' == 'token'
     Get token
     ELSE
-    Log   No authorization method set; failing test setup and skipping test suite
+    Log   No authorization method set. Failing test setup and skipping test suite
     END
 
 

--- a/common/voms.robot
+++ b/common/voms.robot
@@ -21,6 +21,15 @@ Create VOMS proxy   [Arguments]   ${voms.args}=${voms.args.default}
     ${rc}   ${output}   Execute and Check Success   voms-proxy-init ${voms.args}
     [Return]   ${rc}   ${output}
 
+Create Fixture VOMS proxy
+    ${rc}   ${output}   Create VOMS proxy   ${voms.args.default} -out /tmp/x509up_ts_fixture
+    [Return]   ${rc}   ${output}
+
+Enable Fixture VOMS proxy
+    ${proxy_path}   Get proxy path
+    ${rc}   ${output}   Execute and Check Success  cp /tmp/x509up_ts_fixture ${proxy_path}
+    [Return]   ${rc}   ${output}
+    
 Delete VOMS proxy   [Arguments]   ${opts}=${EMPTY}
     ${output}   Execute and Check Success   voms-proxy-destroy ${opts}
     [Return]   ${output}

--- a/test/datalake/__init__.robot
+++ b/test/datalake/__init__.robot
@@ -10,16 +10,8 @@ Resource   common/gfal.robot
 
 Variables   test/variables.yaml
 
-Suite Setup   Run Keywords
-              ...   Set Test Suite Global Variables
-              ...   Set Authorization Method
-              ...   Create Working Directory
-              ...   Cleanup Authorization Environment
-Suite Teardown   Run Keywords
-                 ...   Remove Environment Variable   BEARER_TOKEN
-                 ...   AND   Set Authorization Method
-                 ...   AND   Cleanup Working Directory
-                 ...   AND   Cleanup Authorization Environment
+Suite Setup   Set Parent Suite Environment
+Suite Teardown   Cleanup Parent Suite Environment
 
 
 *** Keywords ***
@@ -45,3 +37,15 @@ Cleanup Working Directory
     ${url}   Suite Base URL
     ${rc}   ${out}   Gfal rm Success   ${url}  -r
     Should Contain   ${out}   RMDIR
+
+Set Parent Suite Environment
+    Set Test Suite Global Variables
+    Set Authorization Method
+    Create Working Directory
+    Cleanup Authorization Environment
+
+Cleanup Parent Suite Environment
+    Remove Environment Variable   BEARER_TOKEN
+    Set Authorization Method
+    Cleanup Working Directory
+    Cleanup Authorization Environment

--- a/test/datalake/__init__.robot
+++ b/test/datalake/__init__.robot
@@ -10,35 +10,38 @@ Resource   common/gfal.robot
 
 Variables   test/variables.yaml
 
-Suite Setup      Create working directory
-Suite Teardown   Cleanup working directory
+Suite Setup   Run Keywords
+              ...   Set Test Suite Global Variables
+              ...   Set Authorization Method
+              ...   Create Working Directory
+              ...   Cleanup Authorization Environment
+Suite Teardown   Run Keywords
+                 ...   Remove Environment Variable   BEARER_TOKEN
+                 ...   AND   Set Authorization Method
+                 ...   AND   Cleanup Working Directory
+                 ...   AND   Cleanup Authorization Environment
 
 
 *** Keywords ***
 
-Create working directory
+Set Test Suite Global Variables
     ${SUITE_UUID}   Generate UUID
     Set Global Variable   ${SUITE_UUID}   ${suite_uuid}
     ${NOW}   Get NOW Time
     Set Global Variable   ${NOW}
-    ${rc}   ${out}   Create VOMS proxy
-    Should Contain   ${out}   Created proxy in
     ${url}   Suite Base URL
+    Set Global Variable   ${url}
+
+Create Working Directory
     ${rc}   ${out}   Gfal mkdir Success   ${url}
     Should Contain   ${out}   ${url}
     ${local_file}   Create Random Temporary File   escape-test-content
-    ${FILE_BASENAME}   Run   basename ${local_file}
-    Set Global Variable   ${FILE_BASENAME}
+    ${file_basename}   Run   basename ${local_file}
     ${rc}   ${out}   Gfal copy Success   ${local_file}   ${url}
-    Should Contain   ${out}   ${url}/${FILE_BASENAME}
-    Remove Temporary file   ${FILE_BASENAME}
-    Delete VOMS proxy
+    Should Contain   ${out}   ${url}/${file_basename}
+    Remove Temporary file   ${file_basename}
 
-Cleanup working directory
-    Remove Environment Variable   BEARER_TOKEN
-    ${rc}   ${out}   Create VOMS proxy
-    Should Contain   ${out}   Created proxy in
+Cleanup Working Directory
     ${url}   Suite Base URL
     ${rc}   ${out}   Gfal rm Success   ${url}  -r
     Should Contain   ${out}   RMDIR
-    Delete VOMS proxy

--- a/test/datalake/__init__.robot
+++ b/test/datalake/__init__.robot
@@ -41,11 +41,12 @@ Cleanup Working Directory
 Set Parent Suite Environment
     Set Test Suite Global Variables
     Set Authorization Method
+    Get Authorization Method
     Create Working Directory
     Cleanup Authorization Environment
 
 Cleanup Parent Suite Environment
     Remove Environment Variable   BEARER_TOKEN
-    Set Authorization Method
+    Get Authorization Method
     Cleanup Working Directory
     Cleanup Authorization Environment

--- a/test/datalake/__init__.robot
+++ b/test/datalake/__init__.robot
@@ -24,22 +24,6 @@ Set Test Suite Global Variables
     ${url}   Suite Base URL
     Set Global Variable   ${url}
 
-Set Authorization Method
-    ${rc}   ${out}   Create VOMS proxy
-    Should Contain   ${out}   Created proxy in
-    ${status}   ${value}   Run Keyword And Ignore Error   Gfal mkdir Success   ${url}
-    IF   '${status}' == 'FAIL'
-    Set Global Variable   ${AUTHZ_METHOD}   token
-    Log    Authorization method used: BEARER token
-    ELSE IF   '${status}' == 'PASS'
-    Set Global Variable   ${AUTHZ_METHOD}   proxy
-    Log    Authorization method used: VOMS proxy
-    ELSE
-    Set Global Variable   ${AUTHZ_METHOD}  None
-    Log   Unexpected Keyword Status: '${status}'
-    END
-    Delete VOMS proxy
-
 Create Working Directory
     ${rc}   ${out}   Gfal mkdir Success   ${url}
     Should Contain   ${out}   ${url}
@@ -56,13 +40,13 @@ Cleanup Working Directory
 
 Set Parent Suite Environment
     Set Test Suite Global Variables
-    Set Authorization Method
-    Get Authorization Method
+    Set Fixture Authorization Method
+    Get Fixture Authorization Method
     Create Working Directory
     Cleanup Authorization Environment
 
 Cleanup Parent Suite Environment
     Remove Environment Variable   BEARER_TOKEN
-    Get Authorization Method
+    Get Fixture Authorization Method
     Cleanup Working Directory
     Cleanup Authorization Environment

--- a/test/datalake/__init__.robot
+++ b/test/datalake/__init__.robot
@@ -24,6 +24,22 @@ Set Test Suite Global Variables
     ${url}   Suite Base URL
     Set Global Variable   ${url}
 
+Set Authorization Method
+    ${rc}   ${out}   Create VOMS proxy
+    Should Contain   ${out}   Created proxy in
+    ${status}   ${value}   Run Keyword And Ignore Error   Gfal mkdir Success   ${url}
+    IF   '${status}' == 'FAIL'
+    Set Global Variable   ${AUTHZ_METHOD}   token
+    Log    Authorization method used: BEARER token
+    ELSE IF   '${status}' == 'PASS'
+    Set Global Variable   ${AUTHZ_METHOD}   proxy
+    Log    Authorization method used: VOMS proxy
+    ELSE
+    Set Global Variable   ${AUTHZ_METHOD}  None
+    Log   Unexpected Keyword Status: '${status}'
+    END
+    Delete VOMS proxy
+
 Create Working Directory
     ${rc}   ${out}   Gfal mkdir Success   ${url}
     Should Contain   ${out}   ${url}

--- a/test/datalake/anonymous_authz/step_0.robot
+++ b/test/datalake/anonymous_authz/step_0.robot
@@ -46,6 +46,6 @@ Delete directory denied to unauthenticated clients
 *** Keywords ***
 
 Set Child Suite Environment
-    Set Authorization Method
+    Get Authorization Method
     Set Suite Environment   anonymous-access-denied   random-content
     Cleanup Authorization Environment

--- a/test/datalake/anonymous_authz/step_0.robot
+++ b/test/datalake/anonymous_authz/step_0.robot
@@ -12,7 +12,7 @@ Force Tags   anonymous-authz   step-0
 
 Suite Setup   Run Keywords   
               ...   Set Authorization Method
-              ...   AND   Set Suite Environment
+              ...   AND   Set Suite Environment   anonymous-access-denied   random-content
               ...   AND   Cleanup Authorization Environment
 
 
@@ -44,11 +44,3 @@ Create directory denied to unauthenticated clients
 Delete directory denied to unauthenticated clients
     ${rc}   ${out}   Gfal rm Error  ${url}   -r
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
-
-
-*** Keywords ***
-
-Set Suite Environment
-    ${url}   ${file.basename}   Upload File in Suite Sub-Directory   anonymous-access-denied   random-content
-    Set Suite Variable   ${url}
-    Set Suite Variable   ${file.basename}

--- a/test/datalake/anonymous_authz/step_0.robot
+++ b/test/datalake/anonymous_authz/step_0.robot
@@ -10,10 +10,7 @@ Variables   test/variables.yaml
 
 Force Tags   anonymous-authz   step-0
 
-Suite Setup   Run Keywords   
-              ...   Set Authorization Method
-              ...   AND   Set Suite Environment   anonymous-access-denied   random-content
-              ...   AND   Cleanup Authorization Environment
+Suite Setup   Set Child Suite Environment
 
 
 *** Test cases ***
@@ -44,3 +41,11 @@ Create directory denied to unauthenticated clients
 Delete directory denied to unauthenticated clients
     ${rc}   ${out}   Gfal rm Error  ${url}   -r
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
+
+
+*** Keywords ***
+
+Set Child Suite Environment
+    Set Authorization Method
+    Set Suite Environment   anonymous-access-denied   random-content
+    Cleanup Authorization Environment

--- a/test/datalake/anonymous_authz/step_0.robot
+++ b/test/datalake/anonymous_authz/step_0.robot
@@ -46,6 +46,6 @@ Delete directory denied to unauthenticated clients
 *** Keywords ***
 
 Set Child Suite Environment
-    Get Authorization Method
+    Get Fixture Authorization Method
     Set Suite Environment   anonymous-access-denied   random-content
     Cleanup Authorization Environment

--- a/test/datalake/anonymous_authz/step_0.robot
+++ b/test/datalake/anonymous_authz/step_0.robot
@@ -10,42 +10,45 @@ Variables   test/variables.yaml
 
 Force Tags   anonymous-authz   step-0
 
+Suite Setup   Run Keywords   
+              ...   Set Authorization Method
+              ...   AND   Set Suite Environment
+              ...   AND   Cleanup Authorization Environment
+
 
 *** Test cases ***
 
 List directory denied to unauthenticated clients
-    ${url}   Suite Base URL
     ${rc}   ${out}   Gfal Read Error   ${url}   -d
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
 
 Read file denied to unauthenticated clients
-    ${url}   Suite Base URL
-    ${rc}   ${out}   Gfal cat Error  ${url}/${FILE_BASENAME}
+    ${rc}   ${out}   Gfal cat Error  ${url}/${file.basename}
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
 
 Write file denied to unauthenticated clients
-    ${uuid}   Generate UUID
-    ${url}   SE URL   write-access-denied-${uuid}
     ${local_file}   Create Random Temporary File
-    ${file.basename}   Run   basename ${local_file}
-    ${rc}   ${out}   Gfal copy Error   ${local_file}   ${url}/${file.basename}   -pf
+    ${file_basename}   Run   basename ${local_file}
+    ${rc}   ${out}   Gfal copy Error   ${local_file}   ${url}/${file_basename}   -pf
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
-    Remove Temporary File   ${file.basename}
+    Remove Temporary File   ${file_basename}
 
 Delete file denied to unauthenticated clients
-    ${url}   ${file.basename}   Upload file in sub-suite Directory with VOMS proxy   anonymous-delete-file-denied
-    Delete VOMS proxy
     ${rc}   ${out}   Gfal rm Error  ${url}/${file.basename}
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
 
 Create directory denied to unauthenticated clients
-    ${uuid}   Generate UUID
-    ${url}   SE URL   write-access-denied-${uuid}
-    ${rc}   ${out}   Gfal mkdir Error   ${url}
+    ${rc}   ${out}   Gfal mkdir Error   ${url}   -p
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
 
 Delete directory denied to unauthenticated clients
-    ${url}   Create sub-suite Directory with VOMS proxy   anonymous-delete-directory-denied
-    Delete VOMS proxy
     ${rc}   ${out}   Gfal rm Error  ${url}   -r
     Should Contain Any   ${out}  401   403   Permission denied   ignore_case=True
+
+
+*** Keywords ***
+
+Set Suite Environment
+    ${url}   ${file.basename}   Upload File in Suite Sub-Directory   anonymous-access-denied   random-content
+    Set Suite Variable   ${url}
+    Set Suite Variable   ${file.basename}

--- a/test/datalake/group_based_authz/step_0.robot
+++ b/test/datalake/group_based_authz/step_0.robot
@@ -49,7 +49,7 @@ ${file.content}   escape-suite-content-file
 *** Keywords ***
 
 Set Child Suite Environment
-    Set Authorization Method
+    Get Authorization Method
     Set Suite Environment   group-based-full-access   ${file.content}
     Cleanup Authorization Environment
     Get token   scope=-s wlcg.groups -s openid

--- a/test/datalake/group_based_authz/step_0.robot
+++ b/test/datalake/group_based_authz/step_0.robot
@@ -10,7 +10,11 @@ Variables   test/variables.yaml
 
 Force Tags   group-based-authz   step-0
 
-Suite Setup   Set suite path and get token with default groups scope
+Suite Setup   Run Keywords   
+              ...   Set Authorization Method
+              ...   AND   Set Suite Environment
+              ...   AND   Cleanup Authorization Environment
+              ...   AND   Get token   scope=-s wlcg.groups -s openid
 Suite Teardown   Remove Environment Variable   BEARER_TOKEN
 
 
@@ -43,12 +47,11 @@ Delete directory allowed to default groups
 
 *** Keywords ***
 
-Set suite path and get token with default groups scope
-    ${url}   ${file}   Upload file in sub-suite Directory with VOMS proxy   group-based-full-access   ${file.content}
+Set Suite Environment
+    ${url}   ${file}   Upload File in Suite Sub-Directory   group-based-full-access   ${file.content}
     Set Suite Variable   ${url}
     Set Suite Variable   ${file}
-    Delete VOMS proxy
-    ${token}   Get token   scope=-s wlcg.groups -s openid
+
 
 *** Variables ***
 

--- a/test/datalake/group_based_authz/step_0.robot
+++ b/test/datalake/group_based_authz/step_0.robot
@@ -12,7 +12,7 @@ Force Tags   group-based-authz   step-0
 
 Suite Setup   Run Keywords   
               ...   Set Authorization Method
-              ...   AND   Set Suite Environment
+              ...   AND   Set Suite Environment   group-based-full-access   ${file.content}
               ...   AND   Cleanup Authorization Environment
               ...   AND   Get token   scope=-s wlcg.groups -s openid
 Suite Teardown   Remove Environment Variable   BEARER_TOKEN
@@ -25,7 +25,7 @@ List directory allowed to default groups
     Should Contain   ${out}   ${url}
 
 Read file allowed to default groups
-    ${rc}   ${out}   Gfal cat Success  ${url}/${file}
+    ${rc}   ${out}   Gfal cat Success  ${url}/${file.basename}
     Should Contain   ${out}   ${file.content}
 
 Write file allowed to default groups
@@ -33,7 +33,7 @@ Write file allowed to default groups
     Should Contain   ${out}   ${url}/services
 
 Delete file allowed to default groups
-    ${rc}   ${out}   Gfal rm Success   ${url}/${file}
+    ${rc}   ${out}   Gfal rm Success   ${url}/${file.basename}
     Should Contain   ${out}   DELETED
 
 Create directory allowed to default groups
@@ -43,14 +43,6 @@ Create directory allowed to default groups
 Delete directory allowed to default groups
     ${rc}   ${out}   Gfal rm Success   ${url}   -r
     Should Contain   ${out}   RMDIR
-
-
-*** Keywords ***
-
-Set Suite Environment
-    ${url}   ${file}   Upload File in Suite Sub-Directory   group-based-full-access   ${file.content}
-    Set Suite Variable   ${url}
-    Set Suite Variable   ${file}
 
 
 *** Variables ***

--- a/test/datalake/group_based_authz/step_0.robot
+++ b/test/datalake/group_based_authz/step_0.robot
@@ -10,11 +10,7 @@ Variables   test/variables.yaml
 
 Force Tags   group-based-authz   step-0
 
-Suite Setup   Run Keywords   
-              ...   Set Authorization Method
-              ...   AND   Set Suite Environment   group-based-full-access   ${file.content}
-              ...   AND   Cleanup Authorization Environment
-              ...   AND   Get token   scope=-s wlcg.groups -s openid
+Suite Setup   Set Child Suite Environment
 Suite Teardown   Remove Environment Variable   BEARER_TOKEN
 
 
@@ -48,3 +44,12 @@ Delete directory allowed to default groups
 *** Variables ***
 
 ${file.content}   escape-suite-content-file
+
+
+*** Keywords ***
+
+Set Child Suite Environment
+    Set Authorization Method
+    Set Suite Environment   group-based-full-access   ${file.content}
+    Cleanup Authorization Environment
+    Get token   scope=-s wlcg.groups -s openid

--- a/test/datalake/group_based_authz/step_0.robot
+++ b/test/datalake/group_based_authz/step_0.robot
@@ -49,7 +49,7 @@ ${file.content}   escape-suite-content-file
 *** Keywords ***
 
 Set Child Suite Environment
-    Get Authorization Method
+    Get Fixture Authorization Method
     Set Suite Environment   group-based-full-access   ${file.content}
     Cleanup Authorization Environment
     Get token   scope=-s wlcg.groups -s openid


### PR DESCRIPTION
Change suite setup/teardown logic.

Basically during suite setup we check whether we have write access with VOMS proxy; if yes, we set VOMS proxy as authorization method, otherwise we set tokens. 

The above authorization method is then used to create suite environment (_i.e._ working directories and uploaded files) for the parent suite and child test suites.

Related issue: #13 